### PR TITLE
fix variable assignment error

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -101,7 +101,7 @@ async function transformDirectoryWalker(content, outputPath) {
       const templateDir = path.dirname(template.inputPath);
       const outputDir = path.dirname(outputPath);
 
-      const assets = [];
+      let assets = [];
       if (pluginOptions.recursive) {
         for await (const file of walk(templateDir)) {
           assets.push(file);


### PR DESCRIPTION
Hi! Thanks for this plugin, looks like a good solution to the ongoing 11ty issue about post folders.
I noticed a small bug though - when running in "directory" mode, I'm seeing this error:

`TemplateWriterWriteError` was thrown: Assignment to constant variable.

this is caused by the re-assignment of `assets` on L110. 
Declaring it as a mutable variable seems to fix the issue.